### PR TITLE
Move paramters from Constructor to init()

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -22,7 +22,7 @@
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
-LiquidCrystal_I2C::LiquidCrystal_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows)
+LiquidCrystal_I2C::LiquidCrystal_I2C()
 {
   _Addr = lcd_Addr;
   _cols = lcd_cols;
@@ -30,30 +30,41 @@ LiquidCrystal_I2C::LiquidCrystal_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t l
   _backlightval = LCD_NOBACKLIGHT;
 }
 
-void LiquidCrystal_I2C::oled_init(){
-  _oled = true;
-	init_priv();
+void LiquidCrystal_I2C::oled_init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t dotsize)
+{
+	_oled = true;
+	_Addr = lcd_Addr;
+	_cols = lcd_cols;
+	_rows = lcd_rows;
+	_dotsize = dotsize;
+	_backlightval = LCD_NOBACKLIGHT;
 }
 
-void LiquidCrystal_I2C::init(){
-	init_priv();
+void LiquidCrystal_I2C::init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t dotsize)
+{
+	_Addr = lcd_Addr;
+	_cols = lcd_cols;
+	_rows = lcd_rows;
+	_dotsize = dotsize;
+	_backlightval = LCD_NOBACKLIGHT;
+	_init_priv();
 }
 
-void LiquidCrystal_I2C::init_priv()
+void LiquidCrystal_I2C::_init()
 {
 	Wire.begin();
 	_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
-	begin(_cols, _rows);  
+	begin();  
 }
 
-void LiquidCrystal_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {	// RK wird dotsize benötigt??
-	if (lines > 1) {
+void LiquidCrystal_I2C::begin()
+{
+	if (_rows > 1) {
 		_displayfunction |= LCD_2LINE;
 	}
-	_numlines = lines;
 
 	// for some 1 line displays you can select a 10 pixel high font
-	if ((dotsize != 0) && (lines == 1)) {
+	if ((_dotsize != 0) && (lines == 1)) {
 		_displayfunction |= LCD_5x10DOTS;
 	}
 
@@ -124,8 +135,8 @@ void LiquidCrystal_I2C::home(){
 
 void LiquidCrystal_I2C::setCursor(uint8_t col, uint8_t row){
 	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
-	if ( row > _numlines ) {
-		row = _numlines-1;    // we count rows starting w/0
+	if ( row > _rows ) {
+		row = _rows-1;    // we count rows starting w/0
 	}
 	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
 }

--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -22,13 +22,7 @@
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
-LiquidCrystal_I2C::LiquidCrystal_I2C()
-{
-  _Addr = lcd_Addr;
-  _cols = lcd_cols;
-  _rows = lcd_rows;
-  _backlightval = LCD_NOBACKLIGHT;
-}
+LiquidCrystal_I2C::LiquidCrystal_I2C() { }
 
 void LiquidCrystal_I2C::oled_init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t dotsize)
 {
@@ -38,6 +32,7 @@ void LiquidCrystal_I2C::oled_init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_
 	_rows = lcd_rows;
 	_dotsize = dotsize;
 	_backlightval = LCD_NOBACKLIGHT;
+	_init();
 }
 
 void LiquidCrystal_I2C::init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t dotsize)
@@ -47,7 +42,7 @@ void LiquidCrystal_I2C::init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows,
 	_rows = lcd_rows;
 	_dotsize = dotsize;
 	_backlightval = LCD_NOBACKLIGHT;
-	_init_priv();
+	_init();
 }
 
 void LiquidCrystal_I2C::_init()
@@ -64,7 +59,7 @@ void LiquidCrystal_I2C::begin()
 	}
 
 	// for some 1 line displays you can select a 10 pixel high font
-	if ((_dotsize != 0) && (lines == 1)) {
+	if ((_dotsize != 0) && (_rows == 1)) {
 		_displayfunction |= LCD_5x10DOTS;
 	}
 

--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -112,6 +112,7 @@ void LiquidCrystal_I2C::begin()
 
 /********** high level commands, for the user! */
 
+/* ******** writes a singel character to the Display     ******************** */
 inline size_t LiquidCrystal_I2C::write(uint8_t value) {
 	send(value, Rs);
 	return 1;
@@ -122,7 +123,7 @@ inline size_t LiquidCrystal_I2C::writeString(char *value) {
 	return writeString(value, strlen(value));
 }
 
-/* ******** writes a string with length to the Display     ****************** */
+/* ******** writes a string with defined length to the Display ************** */
 inline size_t LiquidCrystal_I2C::writeString(char *value, uint8_t length) {
 	uint8_t countChar = 0;
 	uint8_t countI2C = 0;
@@ -143,20 +144,20 @@ inline size_t LiquidCrystal_I2C::writeString(char *value, uint8_t length) {
 }
 
 void LiquidCrystal_I2C::clear(){
-	command(LCD_CLEARDISPLAY);// clear display, set cursor position to zero
-	delayMicroseconds(2000);  // this command takes a long time!	// RK hat HD44780 nicht
+	command(LCD_CLEARDISPLAY);											// clear display, set cursor position to zero
+	delayMicroseconds(2000);  											// this command takes a long time!
 	if (_oled) setCursor(0,0);
 }
 
 void LiquidCrystal_I2C::home(){
-	command(LCD_RETURNHOME);  // set cursor position to zero
-	delayMicroseconds(2000);  // this command takes a long time!	// RK hat HD44780 nicht
+	command(LCD_RETURNHOME);  											// set cursor position to zero
+	delayMicroseconds(2000);  											// this command takes a long time!
 }
 
 void LiquidCrystal_I2C::setCursor(uint8_t col, uint8_t row){
 	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
 	if ( row > _rows ) {
-		row = _rows-1;    // we count rows starting w/0
+		row = _rows-1;    												// we count rows starting w/0
 	}
 	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
 }
@@ -284,7 +285,7 @@ inline void LiquidCrystal_I2C::commandInit(uint8_t value) {
 	Wire.endTransmission();
 }
 
-// write either command or data
+// write single Byte either command or data
 void LiquidCrystal_I2C::send(uint8_t value, uint8_t mode) {
 	Wire.beginTransmission(_Addr);
 	pulseEnable((value&0xF0)|mode|_backlightval);
@@ -295,8 +296,10 @@ void LiquidCrystal_I2C::send(uint8_t value, uint8_t mode) {
 void LiquidCrystal_I2C::pulseEnable(uint8_t _data){
 	Wire.write(_data | En);			// En high
 // enable pulse must be >450ns, next Byte via I2C will need 25us @ 400kHz
+// no delay is required as processing time is bigger than 450ns
 	Wire.write(_data & ~En);		// En low
-// commands need > 37us to settle, next Byte via I2C will need ~40us (25us + processing time)
+// commands need > 37us to settle, next 2 Byte via I2C will need ~55us @ 400kHz (25us per Byte plus start/stop condition)
+// no delay is required as processing time is bigger than 37us
 } 
 
 // Alias functions
@@ -323,9 +326,9 @@ void LiquidCrystal_I2C::load_custom_character(uint8_t char_num, uint8_t *rows){
 
 void LiquidCrystal_I2C::setBacklight(uint8_t new_val){
 	if(new_val){
-		backlight();		// turn backlight on
+		backlight();													// turn backlight on
 	}else{
-		noBacklight();		// turn backlight off
+		noBacklight();													// turn backlight off
 	}
 }
 

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -82,6 +82,7 @@ public:
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
   virtual size_t writeString(char*);
+  virtual size_t writeString(char*, uint8_t);
   void init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
   void oled_init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
 

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -53,8 +53,8 @@
 
 class LiquidCrystal_I2C : public Print {
 public:
-  LiquidCrystal_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows);
-  void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS );
+  LiquidCrystal_I2C();
+  void begin();
   void clear();
   void home();
   void noDisplay();
@@ -82,8 +82,8 @@ public:
   // Example: 	const char bell[8] PROGMEM = {B00100,B01110,B01110,B01110,B11111,B00000,B00100,B00000};
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
-  void init();
-  void oled_init();
+  void init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
+  void oled_init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
 
 ////compatibility API function aliases
   void blink_on();						              // alias for blink()
@@ -107,7 +107,8 @@ void draw_vertical_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixe
 	 
 
 private:
-  void init_priv();
+  void begin();
+  void _init();
   void command(uint8_t);
   void commandInit(uint8_t value);
   void send(uint8_t, uint8_t);
@@ -125,6 +126,7 @@ private:
   bool _oled = false;
   uint8_t _cols;
   uint8_t _rows;
+  uint8_t _dotsize;
   uint8_t _backlightval;
 };
 

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -54,7 +54,6 @@
 class LiquidCrystal_I2C : public Print {
 public:
   LiquidCrystal_I2C();
-  void begin();
   void clear();
   void home();
   void noDisplay();
@@ -112,9 +111,6 @@ private:
   void command(uint8_t);
   void commandInit(uint8_t value);
   void send(uint8_t, uint8_t);
-/*
-  void send_plain(uint8_t value, uint8_t mode);
-*/
   void expanderWrite(uint8_t);
   void pulseEnable(uint8_t);
 

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -81,6 +81,7 @@ public:
   // Example: 	const char bell[8] PROGMEM = {B00100,B01110,B01110,B01110,B11111,B00000,B00100,B00000};
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
+  virtual size_t writeString(char*);
   void init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
   void oled_init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
 


### PR DESCRIPTION
The parameters from the constructor are moved to the init() function to be similiar to the other librayries and to enable a static declaration.