### PR TITLE
buffer length for RaspiPico has another define

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -119,12 +119,12 @@ inline size_t LiquidCrystal_I2C::write(uint8_t value) {
 }
 
 /* ******** writes a NULL terminated string to the Display ****************** */
-inline size_t LiquidCrystal_I2C::writeString(char *value) {
+inline size_t LiquidCrystal_I2C::writeString(const char *value) {
 	return writeString(value, strlen(value));
 }
 
 /* ******** writes a string with defined length to the Display ************** */
-inline size_t LiquidCrystal_I2C::writeString(char *value, uint8_t length) {
+inline size_t LiquidCrystal_I2C::writeString(const char *value, uint8_t length) {
 	uint8_t countChar = 0;
 	uint8_t countI2C = 0;
 	Wire.beginTransmission(_Addr);

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -84,8 +84,8 @@ public:
   // Example: 	const char bell[8] PROGMEM = {B00100,B01110,B01110,B01110,B11111,B00000,B00100,B00000};
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
-  virtual size_t writeString(char*);
-  virtual size_t writeString(char*, uint8_t);
+  virtual size_t writeString(const char*);
+  virtual size_t writeString(const char*, uint8_t);
   void init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
   void oled_init(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
 

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -3,6 +3,9 @@
 #define LiquidCrystal_I2C_h
 
 #include <Wire.h>
+#if defined(ARDUINO_ARCH_RP2040)
+  #define BUFFER_LENGTH WIRE_BUFFER_SIZE
+#endif
 
 // commands
 #define LCD_CLEARDISPLAY    0x01


### PR DESCRIPTION
The Wire library for raspberry Pico uses another #define for the I2C buffer length.
With this addition this library compiles also for this HW platform.
The STM32 platform uses the same definition as the origianal wire library, so no changes are required for this platform.