### PR TITLE
Cursor gets faulty set for 16x4 display

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -155,7 +155,7 @@ void LiquidCrystal_I2C::home(){
 }
 
 void LiquidCrystal_I2C::setCursor(uint8_t col, uint8_t row){
-	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
+	int row_offsets[] = { 0x00, 0x40, _cols, 0x40 + _cols };
 	if ( row > _rows ) {
 		row = _rows-1;    												// we count rows starting w/0
 	}


### PR DESCRIPTION
Setting the cursor for 16x4 displays does not work.
Calculation the position for writing the text into the internal RAM is faulty as a fixed offset for the 3rd and 4th row is used.
Instead the number of columns must be considered.
